### PR TITLE
Add `single-animation` mixin

### DIFF
--- a/animation.gemspec
+++ b/animation.gemspec
@@ -1,10 +1,10 @@
 Gem::Specification.new do |s|
   # Release Specific Information
-  s.version = "0.1.alpha.3"
+  s.version = "0.1.alpha.4"
 
   # Gem Details
   s.name = "animation"
-  s.authors = ["Eric Meyer"]
+  s.authors = ["Eric Meyer", "Jeff Micklos"]
   s.summary = %q{css3 animations plugin for compass}
   s.description = %q{css3 animations plugin for compass, with core animation mixins, and optional defaul animations from animate.css.}
   s.email = "eric@oddbird.net"

--- a/stylesheets/animation/_core.scss
+++ b/stylesheets/animation/_core.scss
@@ -125,3 +125,10 @@ $default-animation-play-state       : false !default;
     $animation-1: -compass-space-list(compact($default-animation-name, $default-animation-duration, $default-animation-timing-function, $default-animation-delay, $default-animation-iteration-count, $default-animation-direction, $default-animation-fill-mode, $default-animation-play-state)); }
   $animation: compact($animation-1, $animation-2, $animation-3, $animation-4, $animation-5, $animation-6, $animation-7, $animation-8, $animation-9, $animation-10);
   @include animation-support(animation, $animation); }
+
+// Provides an interface to generate one animation declaration.
+// Called using comma-seperated values, which keeps consistency
+// with other compass calls.
+@mixin single-animation($animation-name: $default-animation-name, $animation-duration: $default-animation-duration, $animation-delay: $default-animation-delay, $animation-timing-function: $default-animation-timing-function, $animation-iteration-count: $default-animation-iteration-count, $animation-direction: $default-animation-direction, $animation-fill-mode: $default-animation-fill-mode, $animation-play-state: $default-animation-play-state) {
+  @include animation(-compass-space-list(compact($animation-name, $animation-duration, $animation-delay, $animation-timing-function, $animation-iteration-count, $animation-direction, $animation-fill-mode, $animation-play-state)))
+}


### PR DESCRIPTION
Passing a single animation to `animation()` is a bit wonky because you can't comma separate the properties, which is what we have come to expect with compass mixins. `single-animation` follows the same pattern as compass' `single-box-shadow`.
